### PR TITLE
[#28_backend] 登録時のリクエスト項目を修正

### DIFF
--- a/backend/src/main/java/com/meetolio/backend/form/SignupForm.java
+++ b/backend/src/main/java/com/meetolio/backend/form/SignupForm.java
@@ -7,7 +7,4 @@ import lombok.Data;
 public class SignupForm {
     private String email; // メールアドレス
     private String password; // パスワード
-    private String name; // 氏名
-    private String company; // 会社名・組織名
-    private String occupation; // 職種・役職
 }


### PR DESCRIPTION
## 概要
新規登録時の設計変更に伴う、新規登録APIのリクエスト項目修正。
新規登録時には、ポートフォリオレコードは作成せずユーザーテーブルのみを作成する。
よって登録時に受け取るパラメータ値は、メールアドレスとパスワードとする。

## 変更点
- `SignupForm.java`
  - 不必要な項目の削除
- API設計書修正
※ ポートフォリオレコードの追加は未実装だったため、上記変更のみの対応。
 
## テスト
- ローカル環境でのテスト
  - メールアドレス、パスワードの値でユーザーが登録できることを確認

## 関連ドキュメント
- Issue：#28
- ドキュメント：プロジェクトドキュメント（API設計書）