### PR TITLE
[#31_backend] 認証処理の実装

### DIFF
--- a/backend/src/main/java/com/meetolio/backend/common/security/CustomAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/meetolio/backend/common/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,37 @@
+package com.meetolio.backend.common.security;
+
+import java.io.IOException;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.meetolio.backend.common.error.ErrorResponseDto;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+/** カスタム認証エラーハンドリングクラス */
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    /** オブジェクトマッパー */
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+            AuthenticationException authException) throws IOException, ServletException {
+
+        // TODO: メッセージ共通化
+        ErrorResponseDto errorResponseDto = new ErrorResponseDto(HttpServletResponse.SC_UNAUTHORIZED, "ユーザー認証に失敗しました。");
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponseDto));
+    }
+
+}

--- a/backend/src/main/java/com/meetolio/backend/common/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/meetolio/backend/common/security/JwtAuthenticationFilter.java
@@ -1,0 +1,47 @@
+package com.meetolio.backend.common.security;
+
+import java.io.IOException;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+/** 認証フィルター設定クラス */
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    /** JWTService */
+    private final JwtService jwtService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        // Authorizationヘッダーからトークンを取得
+        String authHeader = request.getHeader("Authorization");
+
+        // トークンなしの場合は認証なし
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // トークンを解析し認証
+        String token = authHeader.substring(7);
+
+        String userId = jwtService.extractUserId(token);
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(userId, null, null);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        filterChain.doFilter(request, response);
+    }
+
+}

--- a/backend/src/main/java/com/meetolio/backend/common/security/JwtService.java
+++ b/backend/src/main/java/com/meetolio/backend/common/security/JwtService.java
@@ -3,7 +3,9 @@ package com.meetolio.backend.common.security;
 import org.springframework.stereotype.Service;
 
 import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
 
 /** Jwtトークン操作Service */
 @Service
@@ -15,11 +17,24 @@ public class JwtService {
     /** アルゴリズム */
     private final Algorithm algorithm = Algorithm.HMAC256(SECRET_KEY);
 
+    /** JWTトークン検証用 */
+    private final JWTVerifier verifier = JWT.require(algorithm).build();
+
     /** JWT作成 */
     public String generateToken(Integer userId) {
 
         // subにuserId入れる
         // TODO: 有効期限の設定がなし
         return JWT.create().withSubject(userId.toString()).sign(algorithm);
+    }
+
+    /** JWT解析 */
+    public DecodedJWT verifyToken(String token) {
+        return verifier.verify(token);
+    }
+
+    /** Subject(UserId)の抽出 */
+    public String extractUserId(String token) {
+        return verifyToken(token).getSubject();
     }
 }

--- a/backend/src/main/java/com/meetolio/backend/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/meetolio/backend/common/security/SecurityConfig.java
@@ -2,11 +2,14 @@ package com.meetolio.backend.common.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import lombok.RequiredArgsConstructor;
 
@@ -16,15 +19,32 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    /** 認証フィルター */
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    /** 認証エラーハンドリング */
+    private final CustomAuthenticationEntryPoint customEntryPoint;
+
     /** セキュリティフィルターの設定 */
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 
         // リクエスト認可制御
         http.authorizeHttpRequests(auth -> auth
-                .anyRequest().permitAll());
+                .requestMatchers("/signup", "/login").permitAll()
+                .requestMatchers(HttpMethod.GET, "/portfolio/*").permitAll()
+                .anyRequest().authenticated());
+
         // CSRF無効化
         http.csrf(csrf -> csrf.disable());
+
+        // JWT認証フィルター処理を追加
+        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .sessionManagement(management -> management.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        // エラーハンドリング
+        http.exceptionHandling(ex -> ex
+                .authenticationEntryPoint(customEntryPoint));
 
         return http.build();
     }


### PR DESCRIPTION
## 概要
バックエンドプロジェクトに、認証処理の実装を行う。

## 変更点
- `CustomAuthenticationEntryPoint.java`
  - 認証エラー時のハンドリングクラスを作成
  - 認証エラー時は401ステータスで、エラー共通項目を返すように実装
- `JwtAuthenticationFilter.java`
  - リクエスト時の認証フィルターを作成
  - リクエストヘッダーからトークンを取得
  - トークンを解析し、ユーザー識別子(userId)を取得する
- `JwtService.java`
  - JWTの解析およびSubject抽出のメソッドを作成
- `SecurityConfig.java`
  - 認証フィルター処理をsecurityに追加
  - 「ログイン」「新規登録」「ポートフォリオの取得」以外のリクエストを認証必須にする修正
- API仕様書：共通エラー項目の修正（Notionを参照してください）

## テスト
- ローカル環境でのテスト
  - 認証ヘッダーを付与せずに、テストAPIにアクセス
  → ステータス：401で、レスポンスボディが返却されることを確認。
  - 認証ヘッダーを付与して、テストAPIにアクセス
  → 正常終了することを確認。

## 関連ドキュメント
- Issue：#31
- ドキュメント：プロジェクトドキュメント（API設計書）