### PR TITLE
[#33_backend] アカウント情報取得処理の実装

### DIFF
--- a/backend/src/main/java/com/meetolio/backend/controller/AccountController.java
+++ b/backend/src/main/java/com/meetolio/backend/controller/AccountController.java
@@ -1,0 +1,33 @@
+package com.meetolio.backend.controller;
+
+import java.security.Principal;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.meetolio.backend.dto.AccountResponseDto;
+import com.meetolio.backend.service.AccountService;
+
+import lombok.RequiredArgsConstructor;
+
+/** アカウント関連Controller */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/account")
+public class AccountController {
+
+    /** アカウントService */
+    private final AccountService accountService;
+
+    /** ログインユーザーアカウントの取得 */
+    @GetMapping("/me")
+    public ResponseEntity<AccountResponseDto> getMyAccount(Principal principal) {
+        Integer userId = Integer.parseInt(principal.getName());
+        AccountResponseDto accountResponseDto = accountService.getAccount(userId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(accountResponseDto);
+    }
+}

--- a/backend/src/main/java/com/meetolio/backend/dto/AccountResponseDto.java
+++ b/backend/src/main/java/com/meetolio/backend/dto/AccountResponseDto.java
@@ -1,0 +1,14 @@
+package com.meetolio.backend.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.Data;
+
+/** アカウント情報レスポンス用DTO */
+@Data
+public class AccountResponseDto {
+    private Integer id; // ユーザーID
+    private String email; // メールアドレス
+    private LocalDateTime createdAt; // 作成日時
+    private LocalDateTime updatedAt; // 更新日時
+}

--- a/backend/src/main/java/com/meetolio/backend/repository/UserRepository.java
+++ b/backend/src/main/java/com/meetolio/backend/repository/UserRepository.java
@@ -8,6 +8,9 @@ import com.meetolio.backend.entity.UserEntity;
 @Mapper
 public interface UserRepository {
 
+    /** ID検索 */
+    public UserEntity findById(Integer id);
+
     /** メールアドレス検索 */
     public UserEntity findByEmail(String email);
 

--- a/backend/src/main/java/com/meetolio/backend/service/AccountService.java
+++ b/backend/src/main/java/com/meetolio/backend/service/AccountService.java
@@ -1,0 +1,37 @@
+package com.meetolio.backend.service;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.meetolio.backend.common.error.NotFoundException;
+import com.meetolio.backend.dto.AccountResponseDto;
+import com.meetolio.backend.entity.UserEntity;
+import com.meetolio.backend.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/** アカウント関連Service */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AccountService {
+
+    /** ユーザーRepository */
+    private final UserRepository userRepository;
+
+    /** ユーザーアカウント取得 */
+    public AccountResponseDto getAccount(Integer userId) {
+        UserEntity userEntity = userRepository.findById(userId);
+
+        if (userEntity == null) {
+            // TODO: メッセージ共通化
+            throw new NotFoundException("ユーザーアカウントが見つかりません");
+        }
+
+        ModelMapper mapper = new ModelMapper();
+        AccountResponseDto accountResponseDto = mapper.map(userEntity, AccountResponseDto.class);
+
+        return accountResponseDto;
+    }
+}

--- a/backend/src/main/resources/mapper/UserMapper.xml
+++ b/backend/src/main/resources/mapper/UserMapper.xml
@@ -5,6 +5,13 @@
 <!-- ユーザーテーブルMapper -->
 <mapper namespace="com.meetolio.backend.repository.UserRepository">
 
+    <!-- ID検索 -->
+    <select id="findById">
+        SELECT id, email, created_at, updated_at
+        FROM users
+        WHERE id = #{id}
+    </select>
+
     <!-- メールアドレス検索 -->
     <select id="findByEmail">
         SELECT id, email, password_hash, created_at, updated_at


### PR DESCRIPTION
## 概要
バックエンドプロジェクトに、アカウント情報取得の実装を行う。

## 変更点
- `AccountController.java`,`AccountService.java`
  - アカウント管理用クラスを作成
  - ログインユーザーのアカウント情報取得処理を追加
- `UserRepository.java`, `UserMapper.xml`
  - ユーザーID検索の処理追加
- `AccountResponseDto.java`
  - レスポンス用のアカウントDTOを作成
- API仕様書：アカウント情報取得項目の修正（Notionを参照してください）

## テスト
- ローカル環境でのテスト
  - 認証ヘッダーを付与せずに、APIにアクセス
  → ステータス：401で、レスポンスボディが返却されることを確認。
  - 認証ヘッダーを付与して、APIにアクセス
  → 正常終了することを確認。

## 関連ドキュメント
- Issue：#33
- ドキュメント：プロジェクトドキュメント（API設計書）