### PR TITLE
[#37_backend] メールアドレス、パスワード変更APIの実装

### DIFF
--- a/backend/src/main/java/com/meetolio/backend/controller/AccountController.java
+++ b/backend/src/main/java/com/meetolio/backend/controller/AccountController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.meetolio.backend.dto.AccountResponseDto;
-import com.meetolio.backend.form.AccountUpdateForm;
+import com.meetolio.backend.form.EmailUpdateForm;
 import com.meetolio.backend.service.AccountService;
 
 import lombok.RequiredArgsConstructor;
@@ -34,9 +34,9 @@ public class AccountController {
         return ResponseEntity.status(HttpStatus.OK).body(accountResponseDto);
     }
 
-    /** ログインユーザーメールアドレスの情報更新 */
+    /** ログインユーザーメールアドレスの変更 */
     @PutMapping("/me/email")
-    public ResponseEntity<AccountResponseDto> updateMyEmail(Principal principal, @RequestBody AccountUpdateForm form) {
+    public ResponseEntity<AccountResponseDto> updateMyEmail(Principal principal, @RequestBody EmailUpdateForm form) {
         Integer userId = Integer.parseInt(principal.getName());
         AccountResponseDto accountResponseDto = accountService.updateEmail(userId, form);
 

--- a/backend/src/main/java/com/meetolio/backend/controller/AccountController.java
+++ b/backend/src/main/java/com/meetolio/backend/controller/AccountController.java
@@ -5,10 +5,13 @@ import java.security.Principal;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.meetolio.backend.dto.AccountResponseDto;
+import com.meetolio.backend.form.AccountUpdateForm;
 import com.meetolio.backend.service.AccountService;
 
 import lombok.RequiredArgsConstructor;
@@ -27,6 +30,15 @@ public class AccountController {
     public ResponseEntity<AccountResponseDto> getMyAccount(Principal principal) {
         Integer userId = Integer.parseInt(principal.getName());
         AccountResponseDto accountResponseDto = accountService.getAccount(userId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(accountResponseDto);
+    }
+
+    /** ログインユーザーメールアドレスの情報更新 */
+    @PutMapping("/me/email")
+    public ResponseEntity<AccountResponseDto> updateMyEmail(Principal principal, @RequestBody AccountUpdateForm form) {
+        Integer userId = Integer.parseInt(principal.getName());
+        AccountResponseDto accountResponseDto = accountService.updateEmail(userId, form);
 
         return ResponseEntity.status(HttpStatus.OK).body(accountResponseDto);
     }

--- a/backend/src/main/java/com/meetolio/backend/controller/AccountController.java
+++ b/backend/src/main/java/com/meetolio/backend/controller/AccountController.java
@@ -5,6 +5,7 @@ import java.security.Principal;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.meetolio.backend.dto.AccountResponseDto;
 import com.meetolio.backend.form.EmailUpdateForm;
+import com.meetolio.backend.form.PasswordUpdateForm;
 import com.meetolio.backend.service.AccountService;
 
 import lombok.RequiredArgsConstructor;
@@ -41,5 +43,14 @@ public class AccountController {
         AccountResponseDto accountResponseDto = accountService.updateEmail(userId, form);
 
         return ResponseEntity.status(HttpStatus.OK).body(accountResponseDto);
+    }
+
+    /** ログインユーザーパスワードの変更 */
+    @PostMapping("/me/password")
+    public ResponseEntity<Void> updateMyPassword(Principal principal, @RequestBody PasswordUpdateForm form) {
+        Integer userId = Integer.parseInt(principal.getName());
+        accountService.updatePassword(userId, form);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/backend/src/main/java/com/meetolio/backend/controller/AccountController.java
+++ b/backend/src/main/java/com/meetolio/backend/controller/AccountController.java
@@ -5,7 +5,6 @@ import java.security.Principal;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -46,7 +45,7 @@ public class AccountController {
     }
 
     /** ログインユーザーパスワードの変更 */
-    @PostMapping("/me/password")
+    @PutMapping("/me/password")
     public ResponseEntity<Void> updateMyPassword(Principal principal, @RequestBody PasswordUpdateForm form) {
         Integer userId = Integer.parseInt(principal.getName());
         accountService.updatePassword(userId, form);

--- a/backend/src/main/java/com/meetolio/backend/form/AccountUpdateForm.java
+++ b/backend/src/main/java/com/meetolio/backend/form/AccountUpdateForm.java
@@ -1,0 +1,10 @@
+package com.meetolio.backend.form;
+
+import lombok.Data;
+
+/** アカウント情報更新用Form */
+@Data
+public class AccountUpdateForm {
+    private String email; // メールアドレス
+    private String password; // パスワード
+}

--- a/backend/src/main/java/com/meetolio/backend/form/EmailUpdateForm.java
+++ b/backend/src/main/java/com/meetolio/backend/form/EmailUpdateForm.java
@@ -2,9 +2,9 @@ package com.meetolio.backend.form;
 
 import lombok.Data;
 
-/** アカウント情報更新用Form */
+/** メールアドレス変更用Form */
 @Data
-public class AccountUpdateForm {
+public class EmailUpdateForm {
     private String email; // メールアドレス
     private String password; // パスワード
 }

--- a/backend/src/main/java/com/meetolio/backend/form/PasswordUpdateForm.java
+++ b/backend/src/main/java/com/meetolio/backend/form/PasswordUpdateForm.java
@@ -1,0 +1,10 @@
+package com.meetolio.backend.form;
+
+import lombok.Data;
+
+/** パスワード変更用Form */
+@Data
+public class PasswordUpdateForm {
+    private String currentPassword; // 現在のパスワード
+    private String newPassword; // 新しいパスワード
+}

--- a/backend/src/main/java/com/meetolio/backend/repository/UserRepository.java
+++ b/backend/src/main/java/com/meetolio/backend/repository/UserRepository.java
@@ -16,4 +16,7 @@ public interface UserRepository {
 
     /** ユーザー作成 */
     public void save(UserEntity userEntity);
+
+    /** 更新 */
+    public void update(UserEntity userEntity);
 }

--- a/backend/src/main/java/com/meetolio/backend/service/AccountService.java
+++ b/backend/src/main/java/com/meetolio/backend/service/AccountService.java
@@ -11,7 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.meetolio.backend.common.error.NotFoundException;
 import com.meetolio.backend.dto.AccountResponseDto;
 import com.meetolio.backend.entity.UserEntity;
-import com.meetolio.backend.form.AccountUpdateForm;
+import com.meetolio.backend.form.EmailUpdateForm;
 import com.meetolio.backend.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -44,7 +44,7 @@ public class AccountService {
     }
 
     /** メールアドレス変更 */
-    public AccountResponseDto updateEmail(Integer userId, AccountUpdateForm form) {
+    public AccountResponseDto updateEmail(Integer userId, EmailUpdateForm form) {
         // パスワード一致確認
         UserEntity userEntity = userRepository.findById(userId);
         if (!passwordEncoder.matches(form.getPassword(), userEntity.getPasswordHash())) {

--- a/backend/src/main/java/com/meetolio/backend/service/AccountService.java
+++ b/backend/src/main/java/com/meetolio/backend/service/AccountService.java
@@ -1,12 +1,16 @@
 package com.meetolio.backend.service;
 
+import java.time.LocalDateTime;
+
 import org.modelmapper.ModelMapper;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.meetolio.backend.common.error.NotFoundException;
 import com.meetolio.backend.dto.AccountResponseDto;
 import com.meetolio.backend.entity.UserEntity;
+import com.meetolio.backend.form.AccountUpdateForm;
 import com.meetolio.backend.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -20,6 +24,9 @@ public class AccountService {
     /** ユーザーRepository */
     private final UserRepository userRepository;
 
+    /** パスワードエンコーダー */
+    private final PasswordEncoder passwordEncoder;
+
     /** ユーザーアカウント取得 */
     public AccountResponseDto getAccount(Integer userId) {
         UserEntity userEntity = userRepository.findById(userId);
@@ -31,6 +38,29 @@ public class AccountService {
 
         ModelMapper mapper = new ModelMapper();
         AccountResponseDto accountResponseDto = mapper.map(userEntity, AccountResponseDto.class);
+
+        return accountResponseDto;
+    }
+
+    /** メールアドレス変更 */
+    public AccountResponseDto updateEmail(Integer userId, AccountUpdateForm form) {
+        // パスワード一致確認
+        UserEntity userEntity = userRepository.findById(userId);
+        if (!passwordEncoder.matches(form.getPassword(), userEntity.getPasswordHash())) {
+            // 403ステータスコードをthrowする。
+        }
+
+        // メールアドレス変更
+        userEntity.setEmail(form.getEmail());
+        userEntity.setUpdatedAt(LocalDateTime.now());
+        userRepository.update(userEntity);
+
+        // 変更後の情報をセット
+        AccountResponseDto accountResponseDto = new AccountResponseDto();
+        accountResponseDto.setId(userEntity.getId());
+        accountResponseDto.setEmail(userEntity.getEmail());
+        accountResponseDto.setCreatedAt(userEntity.getCreatedAt());
+        accountResponseDto.setUpdatedAt(userEntity.getUpdatedAt());
 
         return accountResponseDto;
     }

--- a/backend/src/main/java/com/meetolio/backend/service/AccountService.java
+++ b/backend/src/main/java/com/meetolio/backend/service/AccountService.java
@@ -12,6 +12,7 @@ import com.meetolio.backend.common.error.NotFoundException;
 import com.meetolio.backend.dto.AccountResponseDto;
 import com.meetolio.backend.entity.UserEntity;
 import com.meetolio.backend.form.EmailUpdateForm;
+import com.meetolio.backend.form.PasswordUpdateForm;
 import com.meetolio.backend.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -65,5 +66,20 @@ public class AccountService {
         accountResponseDto.setUpdatedAt(userEntity.getUpdatedAt());
 
         return accountResponseDto;
+    }
+
+    /** パスワード変更 */
+    public void updatePassword(Integer userId, PasswordUpdateForm form) {
+        // パスワード一致確認
+        UserEntity userEntity = userRepository.findById(userId);
+        if (!passwordEncoder.matches(form.getCurrentPassword(), userEntity.getPasswordHash())) {
+            // 403ステータスコードをthrowする。
+            throw new AccessDeniedException("パスワードが一致しません");
+        }
+
+        // パスワード変更
+        userEntity.setPasswordHash(passwordEncoder.encode(form.getNewPassword()));
+        userEntity.setUpdatedAt(LocalDateTime.now());
+        userRepository.update(userEntity);
     }
 }

--- a/backend/src/main/java/com/meetolio/backend/service/AccountService.java
+++ b/backend/src/main/java/com/meetolio/backend/service/AccountService.java
@@ -3,6 +3,7 @@ package com.meetolio.backend.service;
 import java.time.LocalDateTime;
 
 import org.modelmapper.ModelMapper;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -48,6 +49,7 @@ public class AccountService {
         UserEntity userEntity = userRepository.findById(userId);
         if (!passwordEncoder.matches(form.getPassword(), userEntity.getPasswordHash())) {
             // 403ステータスコードをthrowする。
+            throw new AccessDeniedException("パスワードが一致しません");
         }
 
         // メールアドレス変更

--- a/backend/src/main/resources/mapper/UserMapper.xml
+++ b/backend/src/main/resources/mapper/UserMapper.xml
@@ -7,7 +7,7 @@
 
     <!-- ID検索 -->
     <select id="findById">
-        SELECT id, email, created_at, updated_at
+        SELECT id, email, password_hash, created_at, updated_at
         FROM users
         WHERE id = #{id}
     </select>

--- a/backend/src/main/resources/mapper/UserMapper.xml
+++ b/backend/src/main/resources/mapper/UserMapper.xml
@@ -24,4 +24,11 @@
         INSERT INTO users(email, password_hash)
         VALUES(#{email}, #{passwordHash})
     </insert>
+
+    <!-- 更新 -->
+    <update id="update">
+        UPDATE users
+        SET email = #{email}, password_hash = #{passwordHash}, updated_at = #{updatedAt}
+        WHERE id = #{id}
+    </update>
 </mapper>


### PR DESCRIPTION
## 概要
バックエンドプロジェクトに、メールアドレス変更API、パスワード変更APIの実装を行う。
当初はアカウント情報更新APIでまとめていたが、責務分離の観点で双方に分けるよう設計を変更。
#41 で実装している共通エラーハンドリングが必要なため、マージを行う。

## 変更点
- `AccountController.java`,`AccountService.java`
  - メールアドレス変更処理を追加
  - パスワード変更処理を追加
- `UserRepository.java`, `UserMapper.xml`
  - ユーザー情報更新のデータ操作処理追加
- `PasswordUpdateForm.java`, `EmailUpdateForm.java`
  - リクエスト用Formクラスを追加
- API仕様書：メールアドレス変更、パスワード変更項目の修正（Notionを参照してください）

## テスト
- ローカル環境でのテスト
  - メールアドレス変更API
    - 正常な条件を設定し実行：ステータス200の更新後ユーザー情報が返却される
    - パスワードが不正な値を設定し実行：ステータス403及びエラーメッセージが返却される
  - パスワード変更API
    - 正常な条件を設定し実行：ステータス204が返却される
    - パスワードが不正な値を設定し実行：ステータス403及びエラーメッセージが返却される

## 関連ドキュメント
- Issue：#37
- ドキュメント：プロジェクトドキュメント（API設計書）