### PR TITLE
ユーザーアカウント削除APIを実装

### DIFF
--- a/backend/src/main/java/com/meetolio/backend/controller/AccountController.java
+++ b/backend/src/main/java/com/meetolio/backend/controller/AccountController.java
@@ -4,6 +4,7 @@ import java.security.Principal;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -49,6 +50,15 @@ public class AccountController {
     public ResponseEntity<Void> updateMyPassword(Principal principal, @RequestBody PasswordUpdateForm form) {
         Integer userId = Integer.parseInt(principal.getName());
         accountService.updatePassword(userId, form);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    /** ログインユーザーアカウントの削除 */
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> deleteMyAccount(Principal principal) {
+        Integer userId = Integer.parseInt(principal.getName());
+        accountService.deleteAccount(userId);
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }

--- a/backend/src/main/java/com/meetolio/backend/repository/PortfolioRepository.java
+++ b/backend/src/main/java/com/meetolio/backend/repository/PortfolioRepository.java
@@ -13,4 +13,7 @@ public interface PortfolioRepository {
 
     /** ポートフォリオの保存 */
     public void save(PortfolioEntity entity);
+
+    /** ユーザーIDによるポートフォリオの削除 */
+    void deleteByUserId(Integer userId);
 }

--- a/backend/src/main/java/com/meetolio/backend/repository/UserRepository.java
+++ b/backend/src/main/java/com/meetolio/backend/repository/UserRepository.java
@@ -19,4 +19,7 @@ public interface UserRepository {
 
     /** 更新 */
     public void update(UserEntity userEntity);
+
+    /** 削除 */
+    public void deleteById(Integer id);
 }

--- a/backend/src/main/java/com/meetolio/backend/service/AccountService.java
+++ b/backend/src/main/java/com/meetolio/backend/service/AccountService.java
@@ -14,6 +14,7 @@ import com.meetolio.backend.entity.UserEntity;
 import com.meetolio.backend.form.EmailUpdateForm;
 import com.meetolio.backend.form.PasswordUpdateForm;
 import com.meetolio.backend.repository.UserRepository;
+import com.meetolio.backend.repository.PortfolioRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,6 +26,9 @@ public class AccountService {
 
     /** ユーザーRepository */
     private final UserRepository userRepository;
+
+    /** ポートフォリオRepository */
+    private final PortfolioRepository portfolioRepository;
 
     /** パスワードエンコーダー */
     private final PasswordEncoder passwordEncoder;
@@ -81,5 +85,20 @@ public class AccountService {
         userEntity.setPasswordHash(passwordEncoder.encode(form.getNewPassword()));
         userEntity.setUpdatedAt(LocalDateTime.now());
         userRepository.update(userEntity);
+    }
+
+    /** アカウント削除 */
+    public void deleteAccount(Integer userId) {
+        // ユーザーの存在確認
+        UserEntity user = userRepository.findById(userId);
+        if (user == null) {
+            throw new NotFoundException("ユーザーが見つかりません");
+        }
+
+        // 関連するポートフォリオを先に削除
+        portfolioRepository.deleteByUserId(userId);
+
+        // ユーザー削除
+        userRepository.deleteById(userId);
     }
 }

--- a/backend/src/main/resources/mapper/PortfolioMapper.xml
+++ b/backend/src/main/resources/mapper/PortfolioMapper.xml
@@ -25,4 +25,10 @@
             description = EXCLUDED.description,
             updated_at = NOW()
     </insert>
+
+    <!-- ユーザーIDでポートフォリオ削除 -->
+    <delete id="deleteByUserId">
+        DELETE FROM portfolios
+        WHERE user_id = #{userId}
+    </delete>
 </mapper>

--- a/backend/src/main/resources/mapper/UserMapper.xml
+++ b/backend/src/main/resources/mapper/UserMapper.xml
@@ -31,4 +31,10 @@
         SET email = #{email}, password_hash = #{passwordHash}, updated_at = #{updatedAt}
         WHERE id = #{id}
     </update>
+
+    <!-- ユーザー削除 -->
+    <delete id="deleteById">
+        DELETE FROM users
+        WHERE id = #{id}
+    </delete>
 </mapper>


### PR DESCRIPTION
## 概要
ユーザーアカウント削除APIを実装しました。
ユーザー削除の前にポートフォリオを削除するようになっています。（要検討）

## 変更点
* controller
  * AccountController.java
  アカウント削除エンドポイントを追加
* service
  * AccountService.java
  アカウント削除処理を追加
* repository
  * PortfolioRepository.java
  ポートフォリオ削除メソッドを追加
  * UserRepository.java
  ユーザー削除メソッドを追加
* resources
  * PortfolioMapper.xml
  ポートフォリオ削除処理を追加
  * UserMapper.xml
  ユーザー削除処理を追加

## テスト
ユーザーの作成からポートフォリオ作成、詳細取得、更新、ユーザー削除までの流れを確認した。

## 関連ドキュメント
issue：https://github.com/study-basic-hackathon/Meetolio/issues/42
ドキュメント：プロジェクトドキュメント（API設計書）