### PR TITLE
アカウント削除画面のデザインを修正

### DIFF
--- a/Frontend/src/pages/DeleteAccount.css
+++ b/Frontend/src/pages/DeleteAccount.css
@@ -175,10 +175,6 @@
   list-style: none;
 }
 
-.warning-list li {
-  margin-bottom: 8px;
-}
-
 .warning-list li:last-child {
   margin-bottom: 0;
 }

--- a/Frontend/src/pages/DeleteAccount.tsx
+++ b/Frontend/src/pages/DeleteAccount.tsx
@@ -56,18 +56,11 @@ const DeleteAccount: React.FC = () => {
     <div className="delete-account">
       <div className="container">
         <div className="edit-form">
-          <div className="form-header">
-            <h2 className="form-title">Meetolioを退会</h2>
-            <p className="form-description">
-              アカウントを削除すると、すべてのデータが完全に削除され、復元できません。
-              この操作は取り消せません。
-            </p>
-          </div>
-
           <form onSubmit={handleSubmit}>
             {/* 入力欄なし（確認のみ） */}
             <div className="form-group">
-              <label>退会する前に</label>
+              <h2 className="form-title">Meetolioを退会</h2>
+              <label>※退会する前に必ずお読みください</label>
               <div className="warning-section">
                 <ul className="warning-list">
                   <li>削除されたデータは復元できません。</li>


### PR DESCRIPTION
アカウント削除画面の無駄な文章を削除。
リストのpaddingも無くし、簡潔なデザインに修正した。